### PR TITLE
Fix times.h for windows.

### DIFF
--- a/src/cspice/sys/times.h
+++ b/src/cspice/sys/times.h
@@ -1,0 +1,39 @@
+// From http://www.linuxjournal.com/article/5574
+
+#ifndef _TIMES_H
+#define _TIMES_H
+
+#ifdef _WIN32
+#include <sys/timeb.h>
+#include <sys/types.h>
+#include <winsock2.h>
+
+int gettimeofday(struct timeval* t,void* timezone);
+
+// from linux's sys/times.h
+
+//#include <features.h>
+
+#define __need_clock_t
+#include <time.h>
+
+
+/* Structure describing CPU time used by a process and its children.  */
+struct tms
+  {
+    clock_t tms_utime;          /* User CPU time.  */
+    clock_t tms_stime;          /* System CPU time.  */
+
+    clock_t tms_cutime;         /* User CPU time of dead children.  */
+    clock_t tms_cstime;         /* System CPU time of dead children.  */
+  };
+
+/* Store the CPU time used by this process and all its
+   dead children (and their dead children) in BUFFER.
+   Return the elapsed real time, or (clock_t) -1 for errors.
+   All times are in CLK_TCKths of a second.  */
+clock_t times (struct tms *__buffer);
+
+typedef long long suseconds_t ;
+#endif
+#endif

--- a/src/cspice/sys/times.h
+++ b/src/cspice/sys/times.h
@@ -35,5 +35,7 @@ struct tms
 clock_t times (struct tms *__buffer);
 
 typedef long long suseconds_t ;
+#else
+#include <sys/times.h>
 #endif
 #endif


### PR DESCRIPTION
The following files

```
cspice/etime_.c
cspice/dtime_.c
```

use `sys/times.h`, which is not available for common windows GCC distributions (MinGW, Cygwin) previously this has been solved by disabling these functions completely. The following pull requests provides a fall back file to solve this more properly.
